### PR TITLE
linkify instead of htmlUnescape in /me

### DIFF
--- a/Web/js/Chat.ts
+++ b/Web/js/Chat.ts
@@ -245,7 +245,7 @@ class Chat {
 
                     case "Action":
                         stateData.Class = "action";
-                        stateData.Content1 = htmlUnescape(stateLine.Content.substr(stateLine.For.length));
+                        stateData.Content1 = this.linkify(stateLine.Content.substr(stateLine.For.length));
                         break;
 
                     default:

--- a/Web/templates/statemessage.mustache
+++ b/Web/templates/statemessage.mustache
@@ -18,6 +18,6 @@
 		</a>
 		{{/ BySteamId }}
 
-		{{ Content2 }}
+		{{{ Content2 }}}
 	{{/ By }}
 </span>

--- a/Web/templates/statemessage.mustache
+++ b/Web/templates/statemessage.mustache
@@ -7,7 +7,7 @@
 	</a>
 	{{/ ForSteamId }}
 
-	{{ Content1 }}
+	{{{ Content1 }}}
 
 	{{# By }}
 		{{# BySteamId }}


### PR DESCRIPTION
`linkify` works with normal messages so makes sense it would work in /me as well.